### PR TITLE
FIX: accidentally set pghost to the name of the deployment object rat…

### DIFF
--- a/k8s/server-deployment.yml
+++ b/k8s/server-deployment.yml
@@ -23,7 +23,7 @@ spec:
           - name: REDIS_PORT
             value: '6379'
           - name: PGHOST
-            value: postgres-deployment
+            value: postgres-cluster-ip-service
           - name: PGPORT
             value: '5432'
           - name: PGUSER


### PR DESCRIPTION
…her than the name of the cluster ip object. This previously caused 'Indexes I have seen' to error out, error found in console.